### PR TITLE
Fix status byte for Note on/off events

### DIFF
--- a/filter/filter.go
+++ b/filter/filter.go
@@ -4,8 +4,8 @@ type FilterMsgType uint8
 
 const (
 	FilterMsgTypeUnknown         = 0x0
-	FilterMsgTypeNoteOn          = 0x8
-	FilterMsgTypeNoteOff         = 0x9
+	FilterMsgTypeNoteOff         = 0x8
+	FilterMsgTypeNoteOn          = 0x9
 	FilterMsgTypeAftertouch      = 0xA
 	FilterMsgTypeControlChange   = 0xB
 	FilterMsgTypeProgramChange   = 0xC

--- a/filternoteoff/filternoteoff.go
+++ b/filternoteoff/filternoteoff.go
@@ -28,7 +28,7 @@ type FilterNoteOffConfig struct {
 }
 
 const (
-	highNibble = 0x90
+	highNibble = 0x80
 )
 
 func New(channel filter.FilterChannel, config json.RawMessage) (*FilterNoteOff, error) {

--- a/filternoteon/filternoteon.go
+++ b/filternoteon/filternoteon.go
@@ -28,7 +28,7 @@ type FilterNoteOnConfig struct {
 }
 
 const (
-	highNibble = 0x80
+	highNibble = 0x90
 )
 
 func New(channel filter.FilterChannel, config json.RawMessage) (*FilterNoteOn, error) {


### PR DESCRIPTION
Hi,
I noticed that Note ON/OFF status messages are opposite from MIDI specification and need to be inverted.

Reference: https://midi.org/summary-of-midi-1-0-messages

* `1000nnnn` for "Note OFF" which is `0x8*`
* `1001nnnn` for "Note ON" which is `0x9*`

So here's a little fix for this.

Cheers!
Thanks for the nifty app! 👍